### PR TITLE
[FIX] Added has consent boolean to interface

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -243,10 +243,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   tiktok_events_sdk:
     dependency: "direct main"
     description:

--- a/lib/src/bridge/tiktok_events_sdk_method_channel.dart
+++ b/lib/src/bridge/tiktok_events_sdk_method_channel.dart
@@ -77,9 +77,9 @@ class MethodChannelTiktokEventsSdk extends TiktokEventsSdkPlatform {
   }
 
   @override
-  Future<void> startTrack() async {
+  Future<void> startTrack({bool hasConsent = false}) async {
     try {
-      await methodChannel.invokeMethod('startTrack');
+      await methodChannel.invokeMethod('startTrack', {'hasConsent': hasConsent});
       log('TikTok tracking started successfully');
     } catch (e, _) {
       throw TikTokException(

--- a/lib/src/bridge/tiktok_events_sdk_method_channel.dart
+++ b/lib/src/bridge/tiktok_events_sdk_method_channel.dart
@@ -77,7 +77,7 @@ class MethodChannelTiktokEventsSdk extends TiktokEventsSdkPlatform {
   }
 
   @override
-  Future<void> startTrack({bool hasConsent = false}) async {
+  Future<void> startTrack({required bool hasConsent}) async {
     try {
       await methodChannel.invokeMethod('startTrack', {'hasConsent': hasConsent});
       log('TikTok tracking started successfully');

--- a/lib/src/bridge/tiktok_events_sdk_platform_interface.dart
+++ b/lib/src/bridge/tiktok_events_sdk_platform_interface.dart
@@ -54,8 +54,8 @@ abstract class TiktokEventsSdkPlatform extends PlatformInterface {
     return _instance.logout();
   }
 
-  Future<void> startTrack() async {
-    return _instance.startTrack();
+  Future<void> startTrack({bool hasConsent = false})  async {
+    return _instance.startTrack(hasConsent: hasConsent);
   }
 
   Future<void> identify({required TikTokIdentifier identifier}) async {

--- a/lib/src/bridge/tiktok_events_sdk_platform_interface.dart
+++ b/lib/src/bridge/tiktok_events_sdk_platform_interface.dart
@@ -54,7 +54,7 @@ abstract class TiktokEventsSdkPlatform extends PlatformInterface {
     return _instance.logout();
   }
 
-  Future<void> startTrack({bool hasConsent = false})  async {
+  Future<void> startTrack({required bool hasConsent})  async {
     return _instance.startTrack(hasConsent: hasConsent);
   }
 

--- a/lib/tiktok_events_sdk.dart
+++ b/lib/tiktok_events_sdk.dart
@@ -102,7 +102,7 @@ class TikTokEventsSdk {
 
   /// SDK will actually start sending app events to TikTok after startTrack() function is called - Use with the disableAutoStart
   static Future<void> startTrack() async {
-    return TiktokEventsSdkPlatform.instance.startTrack();
+    return TiktokEventsSdkPlatform.instance.startTrack(hasConsent: true);
   }
 
   /// Logs a custom event.

--- a/test/tiktok_events_sdk_test.dart
+++ b/test/tiktok_events_sdk_test.dart
@@ -35,8 +35,14 @@ class MockTiktokEventsSdkPlatform with MockPlatformInterfaceMixin implements Tik
   }
 
   @override
-  Future<void> startTrack() async {
+  Future<void> startTrack({bool hasConsent = false}) async {
     await Future.value();
+  }
+
+  @override
+  Future<bool> isAlreadyInitialized() {
+    // TODO: implement isAlreadyInitialized
+    throw UnimplementedError();
   }
 }
 


### PR DESCRIPTION
In the Kotlin code, it’s possible to pass the hasContent parameter, but in the Dart code it is never used; as a result, this method always throws an exception.