### PR TITLE
Migrate plugin to Flutter scenedelegate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ migrate_working_dir/
 .dart_tool/
 build/
 .qodo
+
+.osgrep/
+ios/tiktok_events_sdk/.build/

--- a/ios/Classes/TiktokEventsSdkPlugin.swift
+++ b/ios/Classes/TiktokEventsSdkPlugin.swift
@@ -1,11 +1,13 @@
 import Flutter
 import UIKit
 
-public class TiktokEventsSdkPlugin: NSObject, FlutterPlugin {
+public class TiktokEventsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLifeCycleDelegate {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "tiktok_events_sdk", binaryMessenger: registrar.messenger())
     let instance = TiktokEventsSdkPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
+    registrar.addApplicationDelegate(instance)
+    registrar.addSceneDelegate(instance)
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/ios/tiktok_events_sdk/Package.resolved
+++ b/ios/tiktok_events_sdk/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "tiktok-business-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tiktok/tiktok-business-ios-sdk",
+      "state" : {
+        "revision" : "4d330d4da158190d2c67b2142c2bd36c9eb5291e",
+        "version" : "1.6.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ios/tiktok_events_sdk/Sources/tiktok_events_sdk/TiktokEventsSdkPlugin.swift
+++ b/ios/tiktok_events_sdk/Sources/tiktok_events_sdk/TiktokEventsSdkPlugin.swift
@@ -1,11 +1,13 @@
 import Flutter
 import UIKit
 
-public class TiktokEventsSdkPlugin: NSObject, FlutterPlugin {
+public class TiktokEventsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLifeCycleDelegate {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "tiktok_events_sdk", binaryMessenger: registrar.messenger())
-    let instance = TiktokEventsSdkPlugin()
+
     registrar.addMethodCallDelegate(instance, channel: channel)
+    registrar.addApplicationDelegate(instance)
+    registrar.addSceneDelegate(instance)
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.1.5
 homepage: https://github.com/marcelomoresco/flutter_tiktok_events_sdk
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Migrates the iOS plugin per Flutter 3.38's UIScene lifecycle breaking
change (https://docs.flutter.dev/release/breaking-changes/uiscenedelegate#migration-guide-for-flutter-plugins).

- Conform `TiktokEventsSdkPlugin` to `FlutterSceneLifeCycleDelegate`
- Register on both `addApplicationDelegate` and `addSceneDelegate`
  (legacy + scene-based hosts)
- Bump pubspec to `flutter: ">=3.38.0"` / `sdk: ^3.10.0`
