### PR TITLE
feat: add appSecret support for Android

### DIFF
--- a/android/src/main/kotlin/com/example/tiktok_events_sdk/TikTokMethod.kt
+++ b/android/src/main/kotlin/com/example/tiktok_events_sdk/TikTokMethod.kt
@@ -91,8 +91,14 @@ sealed class TikTokMethod(
                     return
                 }
 
+                val appSecret = options["appSecret"] as? String
+
                 var ttConfig =
-                    TTConfig(context)
+                    if (!appSecret.isNullOrEmpty()) {
+                        TTConfig(context, appSecret)
+                    } else {
+                        TTConfig(context)
+                    }
                         .setAppId(appId)
                         .setTTAppId(tiktokAppId)
                         .setLogLevel(logLevel)

--- a/lib/src/models/config/tiktok_android_options.dart
+++ b/lib/src/models/config/tiktok_android_options.dart
@@ -16,6 +16,12 @@
 /// );
 /// ```
 class TikTokAndroidOptions {
+  /// The app secret used for authenticating requests to the TikTok SDK.
+  ///
+  /// If provided, the SDK will use `TTConfig(context, appSecret)` for initialization.
+  /// If `null`, the SDK will use the default `TTConfig(context)` constructor.
+  final String? appSecret;
+
   /// Whether to disable automatic SDK initialization on app startup.
   ///
   /// If `true`, the SDK will not start automatically when the app launches.
@@ -56,6 +62,7 @@ class TikTokAndroidOptions {
   /// All options are optional and default to `false`, meaning the corresponding features are enabled
   /// (except for `enableAutoIapTrack`, which is disabled by default).
   const TikTokAndroidOptions({
+    this.appSecret,
     this.disableAutoStart = false,
     this.disableAutoEvents = false,
     this.disableInstallLogging = false,
@@ -74,6 +81,7 @@ class TikTokAndroidOptions {
   /// TikTokAndroidOptions updatedOptions = androidOptions.copyWith(disableAutoStart: true);
   /// ```
   TikTokAndroidOptions copyWith({
+    String? appSecret,
     bool? disableAutoStart,
     bool? disableAutoEvents,
     bool? disableInstallLogging,
@@ -83,6 +91,7 @@ class TikTokAndroidOptions {
     bool? disableAdvertiserIDCollection,
   }) {
     return TikTokAndroidOptions(
+      appSecret: appSecret ?? this.appSecret,
       disableAutoStart: disableAutoStart ?? this.disableAutoStart,
       disableAutoEvents: disableAutoEvents ?? this.disableAutoEvents,
       disableInstallLogging:
@@ -106,6 +115,7 @@ class TikTokAndroidOptions {
   /// ```
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
+      'appSecret': appSecret,
       'disableAutoStart': disableAutoStart,
       'disableAutoEvents': disableAutoEvents,
       'disableInstallLogging': disableInstallLogging,
@@ -120,7 +130,8 @@ class TikTokAndroidOptions {
   bool operator ==(covariant TikTokAndroidOptions other) {
     if (identical(this, other)) return true;
 
-    return other.disableAutoStart == disableAutoStart &&
+    return other.appSecret == appSecret &&
+        other.disableAutoStart == disableAutoStart &&
         other.disableAutoEvents == disableAutoEvents &&
         other.disableInstallLogging == disableInstallLogging &&
         other.disableLaunchLogging == disableLaunchLogging &&
@@ -131,7 +142,8 @@ class TikTokAndroidOptions {
 
   @override
   int get hashCode {
-    return disableAutoStart.hashCode ^
+    return appSecret.hashCode ^
+        disableAutoStart.hashCode ^
         disableAutoEvents.hashCode ^
         disableInstallLogging.hashCode ^
         disableLaunchLogging.hashCode ^

--- a/test/tiktok_events_sdk_method_channel_test.dart
+++ b/test/tiktok_events_sdk_method_channel_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tiktok_events_sdk/tiktok_events_sdk.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -17,5 +18,39 @@ void main() {
 
   tearDown(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+  });
+
+  group('TikTokAndroidOptions', () {
+    test('appSecret is null by default', () {
+      const options = TikTokAndroidOptions();
+      expect(options.appSecret, isNull);
+    });
+
+    test('appSecret is included in toMap when provided', () {
+      const options = TikTokAndroidOptions(appSecret: 'test_secret');
+      final map = options.toMap();
+      expect(map['appSecret'], 'test_secret');
+    });
+
+    test('appSecret is null in toMap when not provided', () {
+      const options = TikTokAndroidOptions();
+      final map = options.toMap();
+      expect(map['appSecret'], isNull);
+    });
+
+    test('copyWith preserves appSecret', () {
+      const options = TikTokAndroidOptions(appSecret: 'test_secret');
+      final copied = options.copyWith(disableAutoStart: true);
+      expect(copied.appSecret, 'test_secret');
+      expect(copied.disableAutoStart, isTrue);
+    });
+
+    test('equality includes appSecret', () {
+      const a = TikTokAndroidOptions(appSecret: 'secret1');
+      const b = TikTokAndroidOptions(appSecret: 'secret1');
+      const c = TikTokAndroidOptions(appSecret: 'secret2');
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Adds optional `appSecret` field to `TikTokAndroidOptions`
- Passes it to `TTConfig(context, appSecret)` on the native Android side when provided
- Falls back to `TTConfig(context)` when no secret is given (backwards compatible)
- TikTok's v1.3+ Android SDK requires the app secret for authenticating event data ([docs](https://business-api.tiktok.com/portal/docs/android-integration-steps/v1.3#item-link-2.%20Initialize%20the%20SDK))

## Motivation
The TikTok Events Manager dashboard provides an "App Secret" for each registered app and states it is required to send event data. The iOS side already supports this via `TikTokIosOptions.accessToken`, but the Android side was missing it.

## Usage
```dart
await TikTokEventsSdk.initSdk(
  androidAppId: 'com.example.app',
  tikTokAndroidId: 'YOUR_TIKTOK_APP_ID',
  iosAppId: 'YOUR_IOS_APP_ID',
  tiktokIosId: 'YOUR_TIKTOK_IOS_ID',
  androidOptions: TikTokAndroidOptions(
    appSecret: 'YOUR_APP_SECRET',
  ),
);
```

## Changes
- `TikTokAndroidOptions` — added `appSecret` field, updated `copyWith`, `toMap`, `==`, `hashCode`
- `TikTokMethod.kt` (Android native) — reads `appSecret` from options and uses `TTConfig(context, appSecret)` constructor
- Added unit tests for the new field